### PR TITLE
KPMP-1896: This code change is checked in under the clear cache branc…

### DIFF
--- a/src/main/java/org/kpmp/RegenerateZipFiles.java
+++ b/src/main/java/org/kpmp/RegenerateZipFiles.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.json.JSONObject;
+import org.kpmp.cache.CacheController;
 import org.kpmp.externalProcess.CommandBuilder;
 import org.kpmp.externalProcess.ProcessExecutor;
 import org.kpmp.filters.AuthorizationFilter;
@@ -45,7 +46,7 @@ import org.springframework.context.annotation.FilterType;
 		PackageFileHandler.class }), excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
 				PackageController.class, WebConfig.class, Application.class, AuthorizationFilter.class,
 				GlobusAuthorizationCodeInstalledApp.class, GlobusService.class, StateHandlerService.class,
-				PackageService.class }))
+				PackageService.class, CacheController.class }))
 public class RegenerateZipFiles implements CommandLineRunner {
 
 	private CustomPackageRepository packageRepository;
@@ -108,4 +109,3 @@ public class RegenerateZipFiles implements CommandLineRunner {
 	}
 
 }
-


### PR DESCRIPTION
…h becuase it is related to the script to process large file uploads, but was found with KPMP-1896. Adding the cache controller meant another ignore needed to be added to the regenerate zip file process so Spring did not try to do autowiring for those classes which it does not need